### PR TITLE
Fix: Keep correct position after _jumpTo call

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -466,6 +466,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
       primary.scrollController.jumpTo(0);
       primary.target = index;
       primary.alignment = alignment;
+      if (widget.onItemKey != null) {
+        _lastTargetKey = widget.onItemKey!(primary.target);
+      }
     });
   }
 


### PR DESCRIPTION
Keep position functionality works incorrect after jumping to an item and then inserting some data before first rendered item. Fixed this with reassigning _lastTargetKey with new primary.target key inside _jumpTo method.
